### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.frogr.json
+++ b/org.gnome.frogr.json
@@ -20,8 +20,6 @@
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
         "env": {
             "V": "1"
         }

--- a/org.gnome.frogr.json
+++ b/org.gnome.frogr.json
@@ -19,11 +19,6 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "env": {
-            "V": "1"
-        }
-    },
     "cleanup": [ "/share/man" ],
     "modules": [
         {


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.